### PR TITLE
Fix code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/config/mlflow_server/mlflow_auth_plugin/utils.py
+++ b/config/mlflow_server/mlflow_auth_plugin/utils.py
@@ -11,8 +11,9 @@ os.makedirs( TOKENS_DIRPATH, exist_ok= True)
 def save_tokens(filename: Path, tokens: Dict[str, Any] ) -> None:
     """ Store tokens. """
 
-    filepath = os.path.join(TOKENS_DIRPATH, f"{filename}.json")
-
+    filepath = os.path.normpath(os.path.join(TOKENS_DIRPATH, f"{filename}.json"))
+    if not filepath.startswith(TOKENS_DIRPATH):
+        raise ValueError("Invalid filename")
     with open(filepath, "w", encoding='utf-8') as jfile:
 
         json.dump(tokens, jfile, indent=4)
@@ -22,8 +23,9 @@ def save_tokens(filename: Path, tokens: Dict[str, Any] ) -> None:
 def load_tokens(filename: Path) -> Optional[Dict[str,Any]]:
     """ Load existing tokens. """
 
-    filepath = os.path.join(TOKENS_DIRPATH, f"{filename}.json")
-
+    filepath = os.path.normpath(os.path.join(TOKENS_DIRPATH, f"{filename}.json"))
+    if not filepath.startswith(TOKENS_DIRPATH):
+        raise ValueError("Invalid filename")
     if not os.path.exists(filepath):
 
         return None
@@ -36,15 +38,18 @@ def load_tokens(filename: Path) -> Optional[Dict[str,Any]]:
 def xml_writer(filename: Path, session_root:str )->None:
     '''' Stores xml file from minio response. '''
 
-    filepath = os.path.join(TOKENS_DIRPATH, f"{filename}.xml")
+    filepath = os.path.normpath(os.path.join(TOKENS_DIRPATH, f"{filename}.xml"))
+    if not filepath.startswith(TOKENS_DIRPATH):
+        raise ValueError("Invalid filename")
     session_root = ET.fromstring(session_root)
     tree = ET.ElementTree(session_root)
     tree.write(filepath)
 
 def xml_reader(filename:str)->Optional[ET.Element]:
     ''' Loads xml file if exists. '''
-    filepath = os.path.join(TOKENS_DIRPATH, f"{filename}.xml")
-
+    filepath = os.path.normpath(os.path.join(TOKENS_DIRPATH, f"{filename}.xml"))
+    if not filepath.startswith(TOKENS_DIRPATH):
+        raise ValueError("Invalid filename")
     if not os.path.exists(filepath):
         return None
 


### PR DESCRIPTION
Fixes [https://github.com/HarryKalantzopoulos/MLflow_MINIO_Keycloak-server/security/code-scanning/1](https://github.com/HarryKalantzopoulos/MLflow_MINIO_Keycloak-server/security/code-scanning/1)

To fix the problem, we need to validate the `filename` parameter to ensure it does not contain any malicious path traversal sequences. We can achieve this by normalizing the path and ensuring it remains within the intended directory (`TOKENS_DIRPATH`). 

1. Normalize the path using `os.path.normpath` to remove any ".." segments.
2. Check that the normalized path starts with the `TOKENS_DIRPATH`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
